### PR TITLE
Fix for CVE-2025-24813 and CVE-2025-22235

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -26,9 +26,10 @@
 
     <properties>
         <java.version>17</java.version>
-        <spring.boot.version>3.4.1</spring.boot.version>
-        <spring.cloud.version>2023.0.3</spring.cloud.version>
-        <google.cloud.bom.version>26.43.0</google.cloud.bom.version>
+        <!-- Note: keep in sync with the spring boot version in the <parent> config -->
+        <spring.boot.version>3.5.0</spring.boot.version>
+        <spring.cloud.version>2024.0.1</spring.cloud.version>
+        <google.cloud.bom.version>26.61.0</google.cloud.bom.version>
         <!-- The base image to be used by spring framework to run the services. It must match the target Java version. -->
         <maven.jib.base_image>eclipse-temurin:17</maven.jib.base_image>
     </properties>
@@ -37,7 +38,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.5.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
* bumped spring-boot to 3.5.0
* bumped spring cloud to 2024.0.1
* bumped google cloud bom to 26.62.0
* This resolves CVE-2025-24813 and CVE-2025-22235 and other low impact vulnerabilities