### PR TITLE
ci: add contents: read to main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ name: CI
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Single-job workflow that runs lint + python tests on PR. Adding workflow-level `contents: read` to remove reliance on the repo default token scope. YAML validates.